### PR TITLE
Remove tracking events that duplicate GTM tags

### DIFF
--- a/ckanext/googleanalytics/fanstatic_library/googleanalytics_event_tracking.js
+++ b/ckanext/googleanalytics/fanstatic_library/googleanalytics_event_tracking.js
@@ -6,17 +6,6 @@ this.ckan.module('google-analytics', function (jQuery, _) {
     },
     initialize: function () {
       if (ga) {
-        if (jQuery("meta[property='dataset']")[0] && jQuery("meta[property='dataset']")[0].content) {
-          ga('send', 'event', 'Dataset view by Publisher', jQuery("meta[name='DCTERMS.Creator']")[0].content, jQuery("meta[property='dataset']")[0].content);
-        }
-        jQuery('a.resource-url-analytics').on('click', function () {
-          var resource_url = encodeURIComponent(jQuery(this).prop('href'));
-          if (resource_url) {
-            ga('send', 'event', 'Resource', 'Download', resource_url);
-            ga('send', 'event', 'Download by Dataset', jQuery("meta[property='dataset']")[0].content, resource_url);
-            ga('send', 'event', 'Download by Publisher', jQuery("meta[name='DCTERMS.Creator']")[0].content, resource_url);
-          }
-        });
         jQuery('a.searchpartnership-url-analytics').on('click', function () {
           var dataset_url = encodeURIComponent(jQuery(this).prop('href'));
           var dataset_portal = encodeURIComponent(jQuery(this).attr('data-portal'));


### PR DESCRIPTION
Downloads and view events are handled in Tag Manager on data.gov.au now.
The removed events already exist in GTM, and duplicate these tags.

We could reverse this (and remove GTM) if we're willing to invest time in manually setting up the events and variables in this file.